### PR TITLE
[MERGE] Update Boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -829,4 +829,6 @@ mysqldata
 
 .vscode
 
+deploy.json
+
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,linux,visualstudio,visualstudiocode,intellij+all,eclipse,sublimetext,git,node,dotenv

--- a/src/db/db.service.ts
+++ b/src/db/db.service.ts
@@ -14,7 +14,7 @@ export class DbService implements TypeOrmOptionsFactory {
       password: this.config.get('DATABASE_PASSWORD'),
       port: this.config.get('DATABASE_PORT'),
       database: this.config.get('DATABASE_NAME'),
-      entities: [this.config.get('ENTITY_PATH')],
+      autoLoadEntities: true,
     };
   }
 }


### PR DESCRIPTION
Boilerplate 변경
- 기존 TypeORM에서 사용하던 ENTITY 환경변수 삭제
- DBService에서 TypeORMFactory가 제공하는 autoloadentity옵션 활성화

이후 프로젝트에서 수동으로 ENTITY_PATH를 등록해줄 필요 없음